### PR TITLE
Person.search returns empty results because query is double-escaped

### DIFF
--- a/lib/google_plus/activity.rb
+++ b/lib/google_plus/activity.rb
@@ -24,7 +24,7 @@ module GooglePlus
     # @return [GooglePlus::Cursor] a cursor that will paginate through the results
     #   for the activity search
     def self.search(query, params = {})
-      params[:query] = URI.escape(query)
+      params[:query] = query
       params[:orderBy] = params.delete(:order_by) if params.has_key?(:order_by)
       resource = 'activities'
       GooglePlus::Cursor.new(self, :get, resource, params)

--- a/lib/google_plus/person.rb
+++ b/lib/google_plus/person.rb
@@ -23,7 +23,7 @@ module GooglePlus
     # @option params [Symbol] :user_ip The IP of the user on who's behalf this request is made
     # @return [GooglePlus::Cursor] a cursor for the people found in the search
     def self.search(query, params = {})
-      params[:query] = URI.escape(query)
+      params[:query] = query
       resource = 'people'
       GooglePlus::Cursor.new(self, :get, resource, params)
     end


### PR DESCRIPTION
The search example in the readme does not work because the search is empty:

``` ruby
search = GooglePlus::Person.search('john crepezzi')
search.each do |p|
  puts p.display_name
end
```

The gem code and RestClient are both escaping the query parameter, causing the url to contain query=john%2520crepezzi

The Activities API handles the double escaped parameter better, but it is also double-escaped
