### PR TITLE
Handling RestClient::RequestURITooLong exception in resource.rb

### DIFF
--- a/lib/google_plus/resource.rb
+++ b/lib/google_plus/resource.rb
@@ -25,7 +25,7 @@ module GooglePlus
         raise GooglePlus::RequestError.new(e)
       rescue SocketError => e
         raise GooglePlus::ConnectionError.new(e)
-      rescue RestClient::ResourceNotFound
+      rescue RestClient::ResourceNotFound, RestClient::RequestURITooLong
         nil
       end
     end


### PR DESCRIPTION
I often get this RestClient::RequestURITooLong exception when I am fetching items using:

cursor  = GooglePlus::Activity::search('apple', {:language => 'en-US', :orderBy => 'best'})
cursor.each { |item| ... }
