### PR TITLE
Fetch 100 results(max.) if doing each

### DIFF
--- a/lib/google_plus/cursor.rb
+++ b/lib/google_plus/cursor.rb
@@ -10,7 +10,7 @@ module GooglePlus
     # @yieldparam [GooglePlus::Entity] an individual item
     # @yieldreturn [GooglePlus::Cursor] self
     def each
-      while items = next_page
+      while items = next_page({:max_results => 100})
         break if items.empty?
         items.each do |item|
           yield item


### PR DESCRIPTION
Instead of fetching the default which is 20 on each request, fetch 100 to decrease number of queries since we're doing an each anyways.
