### PR TITLE
Update rest-client to support new cipher handling in Ruby 2.4.x

### DIFF
--- a/google_plus.gemspec
+++ b/google_plus.gemspec
@@ -7,7 +7,7 @@ spec = Gem::Specification.new do |s|
   s.description = 'Google+ Ruby Gem'
   s.email = 'john.crepezzi@gmail.com'
   s.add_development_dependency 'rspec'
-  s.add_dependency 'rest-client', '~> 1.6'
+  s.add_dependency 'rest-client', '~> 2.0.1'
   s.add_dependency 'json'
   s.files = Dir['lib/**/*.rb'] + ['README.md']
   s.has_rdoc = true


### PR DESCRIPTION
Fore more details, follow the discussion at:
https://github.com/rest-client/rest-client/issues/569